### PR TITLE
Update to 20w21a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.15
-yarn_mappings=1.15+build.2
-loader_version=0.7.2+build.174
+minecraft_version=20w21a
+yarn_mappings=20w21a+build.16
+loader_version=0.8.4+build.198
 
 # Mod Properties
 mod_version = 1.0.0

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/ReachEntityAttributes.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/ReachEntityAttributes.java
@@ -3,10 +3,12 @@ package com.jamieswhiteshirt.reachentityattributes;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.ClampedEntityAttribute;
 import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 public class ReachEntityAttributes {
-    public static final EntityAttribute REACH = (new ClampedEntityAttribute(null, "generic.reach-entity-attributes.reach", 0.0D, -1024.0D, 1024.0D)).setName("Reach").setTracked(true);
-    public static final EntityAttribute ATTACK_RANGE = (new ClampedEntityAttribute(null, "generic.reach-entity-attributes.attackRange", 0.0D, -1024.0D, 1024.0D)).setName("Attack Range").setTracked(true);
+    public static final EntityAttribute REACH = register("reach", new ClampedEntityAttribute("generic.reach-entity-attributes.reach", 0.0D, -1024.0D, 1024.0D)).setTracked(true);
+    public static final EntityAttribute ATTACK_RANGE = register("attack_range", new ClampedEntityAttribute("generic.reach-entity-attributes.attack_range", 0.0D, -1024.0D, 1024.0D)).setTracked(true);
 
     public static double getReachDistance(LivingEntity entity, double baseValue) {
         return baseValue + entity.getAttributeInstance(REACH).getValue();
@@ -26,5 +28,11 @@ public class ReachEntityAttributes {
         double baseValue = Math.sqrt(squaredBaseValue);
         double value = baseValue + entity.getAttributeInstance(ReachEntityAttributes.ATTACK_RANGE).getValue();
         return value * value;
+    }
+
+    private static EntityAttribute register(String name, EntityAttribute attribute) {
+        Registry.register(Registry.ATTRIBUTES, new Identifier("reach-entity-attributes", name), attribute);
+
+        return attribute;
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/LivingEntityMixin.java
@@ -4,11 +4,12 @@ import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
@@ -17,11 +18,12 @@ public abstract class LivingEntityMixin extends Entity {
     }
 
     @Inject(
-        method = "initAttributes()V",
-        at = @At("TAIL")
+        method = "createLivingAttributes()Lnet/minecraft/entity/attribute/DefaultAttributeContainer$Builder;",
+        at = @At("RETURN"),
+        cancellable = true
     )
-    private void initAttributes(CallbackInfo ci) {
-        ((LivingEntity) (Object) this).getAttributes().register(ReachEntityAttributes.REACH);
-        ((LivingEntity) (Object) this).getAttributes().register(ReachEntityAttributes.ATTACK_RANGE);
+    private static void initAttributes(CallbackInfoReturnable<DefaultAttributeContainer.Builder> ci) {
+        ci.getReturnValue().add(ReachEntityAttributes.REACH);
+        ci.getReturnValue().add(ReachEntityAttributes.ATTACK_RANGE);
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
     @ModifyConstant(
-        method = "onPlayerInteractEntity(Lnet/minecraft/server/network/packet/PlayerInteractEntityC2SPacket;)V",
+        method = "onPlayerInteractEntity(Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket;)V",
         constant = {
             @Constant(doubleValue = 36.0D),
             @Constant(doubleValue = 9.0D)
@@ -20,7 +20,7 @@ public abstract class ServerPlayNetworkHandlerMixin {
     }
 
     @ModifyConstant(
-        method = "onPlayerInteractBlock(Lnet/minecraft/server/network/packet/PlayerInteractBlockC2SPacket;)V",
+        method = "onPlayerInteractBlock(Lnet/minecraft/network/packet/c2s/play/PlayerInteractBlockC2SPacket;)V",
         constant = {
             @Constant(doubleValue = 64.0D)
         }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(ServerPlayerInteractionManager.class)
 public abstract class ServerPlayerInteractionManagerMixin {
     @ModifyConstant(
-        method = "processBlockBreakingAction(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/server/network/packet/PlayerActionC2SPacket$Action;Lnet/minecraft/util/math/Direction;I)V",
+        method = "processBlockBreakingAction(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/network/packet/c2s/play/PlayerActionC2SPacket$Action;Lnet/minecraft/util/math/Direction;I)V",
         constant = @Constant(doubleValue = 36.0D)
     )
     private double modifyReachDistance(double value) {


### PR DESCRIPTION
Had to change the identifier for the attackRange attribute to "attack_range" due to Minecraft's identifier naming requirements. Besides that change, others are made to accommodate for 1.16's changes to the entity attribute system and new mappings.