### PR TITLE
Update to 1.16.4+ resource loader and mappings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=20w21a
-yarn_mappings=20w21a+build.16
-loader_version=0.8.4+build.198
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+
+loader_version=0.10.8
 
 # Mod Properties
-mod_version = 1.0.1
+mod_version = 1.1.0
 maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
-fabric_resource_loader_v0_version=0.1.+
+fabric_resource_loader_v0_version=0.3.5+
 
 jsr305_version=3.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
 minecraft_version=1.16.4
-yarn_mappings=1.16.4+
+yarn_mappings=1.16.4+build.7
 loader_version=0.10.8
 
 # Mod Properties
@@ -13,7 +13,7 @@ maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
-fabric_resource_loader_v0_version=0.3.5+
+# https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-resource-loader-v0/maven-metadata.xml
+fabric_resource_loader_v0_version=0.3.5+e1f1abb18e
 
 jsr305_version=3.0.2

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/ReachEntityAttributes.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/ReachEntityAttributes.java
@@ -16,7 +16,7 @@ public class ReachEntityAttributes {
 
     public static double getSquaredReachDistance(LivingEntity entity, double squaredBaseValue) {
         double baseReachDistance = Math.sqrt(squaredBaseValue);
-        double value = baseReachDistance + entity.getAttributeInstance(ReachEntityAttributes.REACH).getValue();
+        double value = baseReachDistance + entity.getAttributeInstance(REACH).getValue();
         return value * value;
     }
 
@@ -26,11 +26,11 @@ public class ReachEntityAttributes {
 
     public static double getSquaredAttackRange(LivingEntity entity, double squaredBaseValue) {
         double baseValue = Math.sqrt(squaredBaseValue);
-        double value = baseValue + entity.getAttributeInstance(ReachEntityAttributes.ATTACK_RANGE).getValue();
+        double value = baseValue + entity.getAttributeInstance(ATTACK_RANGE).getValue();
         return value * value;
     }
 
     private static EntityAttribute register(String name, EntityAttribute attribute) {
-        return Registry.register(Registry.ATTRIBUTES, new Identifier("reach-entity-attributes", name), attribute);
+        return Registry.register(Registry.ATTRIBUTE, new Identifier("reach-entity-attributes", name), attribute);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,8 +17,9 @@
     "mixins.reach-entity-attributes.json"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
-    "fabric-resource-loader-v0": "*"
+    "minecraft": ">=1.16.4",
+    "fabricloader": ">=0.10.8",
+    "fabric-resource-loader-v0": ">=0.3.5"
   },
   "custom": {
     "modmenu:api": true

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,9 +17,8 @@
     "mixins.reach-entity-attributes.json"
   ],
   "depends": {
-    "minecraft": ">=1.16.4",
-    "fabricloader": ">=0.10.8",
-    "fabric-resource-loader-v0": ">=0.3.5"
+    "fabricloader": ">=0.4.0",
+    "fabric-resource-loader-v0": "*"
   },
   "custom": {
     "modmenu:api": true


### PR DESCRIPTION
The mod functions perfectly on 1.16 and 1.17 (tested on 20w49a), but the embedded resource loader is incompatible, so a new build is needed that embeds this up-to-date resource loader version.