### PR TITLE
Add support for inventory interaction (#7)

### DIFF
--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
@@ -1,0 +1,30 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.screen.ForgingScreenHandler;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+// For some reason this class does not use the static helper method in the superclass
+@Mixin(ForgingScreenHandler.class) // Anvil, Smithing Table
+public abstract class ForgingScreenHandlerMixin extends ScreenHandler {
+    protected ForgingScreenHandlerMixin(@Nullable ScreenHandlerType<?> screenHandlerType, int i) {
+        super(screenHandlerType, i);
+    }
+
+    @ModifyConstant(
+        //private synthetic method_24924(PlayerEntity,World,BlockPos)Boolean
+        method = "method_24924",
+        constant = {
+            @Constant(doubleValue = 64.0D)
+        }
+    )
+    private double modifyReachDistance(double value, PlayerEntity player) {
+        return ReachEntityAttributes.getSquaredReachDistance(player, value);
+    }
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
@@ -10,8 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-// For some reason this class does not use the static helper method in the superclass
-@Mixin(ForgingScreenHandler.class) // Anvil, Smithing Table
+@Mixin(ForgingScreenHandler.class)
 public abstract class ForgingScreenHandlerMixin extends ScreenHandler {
     protected ForgingScreenHandlerMixin(@Nullable ScreenHandlerType<?> screenHandlerType, int i) {
         super(screenHandlerType, i);

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ForgingScreenHandlerMixin.java
@@ -5,14 +5,13 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.screen.ForgingScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ForgingScreenHandler.class)
 public abstract class ForgingScreenHandlerMixin extends ScreenHandler {
-    protected ForgingScreenHandlerMixin(@Nullable ScreenHandlerType<?> screenHandlerType, int i) {
+    protected ForgingScreenHandlerMixin(ScreenHandlerType<?> screenHandlerType, int i) {
         super(screenHandlerType, i);
     }
 

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryImplsMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryImplsMixin.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
     EnderChestBlockEntity.class,
     LootableContainerBlockEntity.class,
     PlayerInventory.class,
-    StorageMinecartEntity.class // Minecart with Chest, Minecart with Hopper
+    StorageMinecartEntity.class
 }, targets = {
     "net.minecraft.block.entity.LecternBlockEntity$1"
 })

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryImplsMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryImplsMixin.java
@@ -1,0 +1,36 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.block.entity.BrewingStandBlockEntity;
+import net.minecraft.block.entity.EnderChestBlockEntity;
+import net.minecraft.block.entity.LootableContainerBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.entity.vehicle.StorageMinecartEntity;
+import net.minecraft.inventory.Inventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(value = {
+    AbstractFurnaceBlockEntity.class,
+    BrewingStandBlockEntity.class,
+    EnderChestBlockEntity.class,
+    LootableContainerBlockEntity.class,
+    PlayerInventory.class,
+    StorageMinecartEntity.class // Minecart with Chest, Minecart with Hopper
+}, targets = {
+    "net.minecraft.block.entity.LecternBlockEntity$1"
+})
+public abstract class InventoryImplsMixin implements Inventory {
+    @ModifyConstant(
+        method = "canPlayerUse",
+        constant = {
+            @Constant(doubleValue = 64.0D)
+        }
+    )
+    private static double modifyReachDistance(double value, PlayerEntity player) {
+        return ReachEntityAttributes.getSquaredReachDistance(player, value);
+    }
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ScreenHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ScreenHandlerMixin.java
@@ -17,7 +17,7 @@ public abstract class ScreenHandlerMixin {
             @Constant(doubleValue = 64.0D)
         }
     )
-    private static double modifyReachDistance(double value, /*Method parameters*/ Block block, PlayerEntity player) {
+    private static double modifyReachDistance(double value, Block block, PlayerEntity player) {
         return ReachEntityAttributes.getSquaredReachDistance(player, value);
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ScreenHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ScreenHandlerMixin.java
@@ -1,0 +1,23 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.screen.ScreenHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ScreenHandler.class)
+public abstract class ScreenHandlerMixin {
+    @ModifyConstant(
+        //private static synthetic method_17696(Block,PlayerEntity,World,BlockPos)Boolean
+        method = "method_17696",
+        constant = {
+            @Constant(doubleValue = 64.0D)
+        }
+    )
+    private static double modifyReachDistance(double value, /*Method parameters*/ Block block, PlayerEntity player) {
+        return ReachEntityAttributes.getSquaredReachDistance(player, value);
+    }
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,6 +1,7 @@
 package com.jamieswhiteshirt.reachentityattributes.mixin;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
@@ -11,12 +12,15 @@ public abstract class ServerPlayNetworkHandlerMixin {
     @ModifyConstant(
         method = "onPlayerInteractEntity(Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket;)V",
         constant = {
-            @Constant(doubleValue = 36.0D),
-            @Constant(doubleValue = 9.0D)
+            @Constant(doubleValue = 36.0D)
         }
     )
-    private double modifyAttackRange(double value) {
-        return ReachEntityAttributes.getSquaredAttackRange(((ServerPlayNetworkHandler) (Object) this).player, value);
+    private double modifyAttackRange(double value, PlayerInteractEntityC2SPacket packet) {
+        if (packet.getType() == PlayerInteractEntityC2SPacket.InteractionType.ATTACK) {
+            return ReachEntityAttributes.getSquaredAttackRange(((ServerPlayNetworkHandler) (Object) this).player, value);
+        }
+        // INTERACT, INTERACT_AT
+        return ReachEntityAttributes.getSquaredReachDistance(((ServerPlayNetworkHandler) (Object) this).player, value);
     }
 
     @ModifyConstant(

--- a/src/main/resources/mixins.reach-entity-attributes.json
+++ b/src/main/resources/mixins.reach-entity-attributes.json
@@ -3,10 +3,13 @@
   "package": "com.jamieswhiteshirt.reachentityattributes.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "ForgingScreenHandlerMixin",
+    "InventoryImplsMixin",
     "LivingEntityMixin",
     "PlayerEntityMixin",
-    "ServerPlayerInteractionManagerMixin",
-    "ServerPlayNetworkHandlerMixin"
+    "ScreenHandlerMixin",
+    "ServerPlayNetworkHandlerMixin",
+    "ServerPlayerInteractionManagerMixin"
   ],
   "client": [
     "client.ClientPlayerInteractionManagerMixin",


### PR DESCRIPTION
Adds the necessary patches to support interaction with inventories at extended block reach.

![Recording of a chest being opened at an extended block reach](https://i.imgur.com/vdH7UUF.gif)