### PR TITLE
Updated to 1.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel = true
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.19-rc2
-yarn_mappings=1.19-rc2+build.1
-loader_version=0.14.6
+minecraft_version=1.19
+yarn_mappings=1.19+build.2
+loader_version=0.14.7
 
 # Mod Properties
 mod_version = 2.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel = true
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version = 1.18.2
-yarn_mappings = 1.18.2+build.2:v2
-loader_version = 0.13.3
+minecraft_version=1.19-rc2
+yarn_mappings=1.19-rc2+build.1
+loader_version=0.14.6
 
 # Mod Properties
 mod_version = 2.2.0
@@ -14,5 +14,5 @@ maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
-fabric_version = 0.48.0+1.18.2
+fabric_version = 0.55.1+1.19
 jsr305_version = 3.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
-fabric_version = 0.55.1+1.19
+fabric_version = 0.55.3+1.19
 jsr305_version = 3.0.2

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryValidationMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/InventoryValidationMixin.java
@@ -17,8 +17,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
     AbstractFurnaceBlockEntity.class,
     BrewingStandBlockEntity.class,
     LootableContainerBlockEntity.class,
-    PlayerInventory.class,
-    StorageMinecartEntity.class
+    PlayerInventory.class
 }, targets = {
     "net.minecraft.block.entity.LecternBlockEntity$1"
 })

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayNetworkHandlerMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.network.listener.ServerPlayPacketListener;
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,7 +28,7 @@ abstract class ServerPlayNetworkHandlerMixin implements ServerPlayPacketListener
         at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;MAX_BREAK_SQUARED_DISTANCE:D", opcode = Opcodes.GETSTATIC)
     )
     private double getActualAttackRange() {
-        return ReachEntityAttributes.getSquaredReachDistance(this.player, 36.0);
+        return ReachEntityAttributes.getSquaredReachDistance(this.player, ServerPlayNetworkHandler.MAX_BREAK_SQUARED_DISTANCE);
     }
 
     @Redirect(
@@ -35,7 +36,7 @@ abstract class ServerPlayNetworkHandlerMixin implements ServerPlayPacketListener
         at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;MAX_BREAK_SQUARED_DISTANCE:D", opcode = Opcodes.GETSTATIC)
     )
     private double getActualReachDistance() {
-        return ReachEntityAttributes.getSquaredReachDistance(this.player, 36.0);//ReachEntityAttributes.getSquaredReachDistance(this.player, reachDistance);
+        return ReachEntityAttributes.getSquaredReachDistance(this.player, ServerPlayNetworkHandler.MAX_BREAK_SQUARED_DISTANCE);
     }
 
     @ModifyConstant(

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
@@ -3,20 +3,23 @@ package com.jamieswhiteshirt.reachentityattributes.mixin;
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayerInteractionManager.class)
 abstract class ServerPlayerInteractionManagerMixin {
     @Shadow @Final protected ServerPlayerEntity player;
 
-    @ModifyConstant(
-        method = "processBlockBreakingAction(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/network/packet/c2s/play/PlayerActionC2SPacket$Action;Lnet/minecraft/util/math/Direction;I)V",
-        require = 1, allow = 1, constant = @Constant(doubleValue = 36.0))
-    private double getActualReachDistance(final double reachDistance) {
-        return ReachEntityAttributes.getSquaredReachDistance(this.player, reachDistance);
+    @Redirect(
+        method = "processBlockBreakingAction",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;MAX_BREAK_SQUARED_DISTANCE:D", opcode = Opcodes.GETSTATIC))
+    private double getActualReachDistance() {
+        return ReachEntityAttributes.getSquaredReachDistance(this.player, 36.0);
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/ServerPlayerInteractionManagerMixin.java
@@ -1,6 +1,7 @@
 package com.jamieswhiteshirt.reachentityattributes.mixin;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
 import org.objectweb.asm.Opcodes;
@@ -20,6 +21,6 @@ abstract class ServerPlayerInteractionManagerMixin {
         method = "processBlockBreakingAction",
         at = @At(value = "FIELD", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;MAX_BREAK_SQUARED_DISTANCE:D", opcode = Opcodes.GETSTATIC))
     private double getActualReachDistance() {
-        return ReachEntityAttributes.getSquaredReachDistance(this.player, 36.0);
+        return ReachEntityAttributes.getSquaredReachDistance(this.player, ServerPlayNetworkHandler.MAX_BREAK_SQUARED_DISTANCE);
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
@@ -1,0 +1,33 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.vehicle.ChestBoatEntity;
+import net.minecraft.entity.vehicle.StorageMinecartEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = {
+    StorageMinecartEntity.class,
+    ChestBoatEntity.class
+})
+public abstract class VehicleInventoryValidationMixin extends Entity {
+
+    public VehicleInventoryValidationMixin(EntityType<?> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Inject(method = "canPlayerUse", at = @At("RETURN"), cancellable = true)
+    private void canPlayerUseWithActualReachDistance(PlayerEntity playerEntity, CallbackInfoReturnable<Boolean> cir) {
+        double reachDistance = ReachEntityAttributes.getReachDistance(playerEntity, 8.0);
+        boolean canUse = !isRemoved() && this.getPos().isInRange(playerEntity.getPos(), reachDistance);
+        if(canUse != cir.getReturnValue()) {
+            cir.setReturnValue(canUse);
+        }
+    }
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
@@ -1,33 +1,18 @@
 package com.jamieswhiteshirt.reachentityattributes.mixin;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.vehicle.ChestBoatEntity;
-import net.minecraft.entity.vehicle.StorageMinecartEntity;
-import net.minecraft.world.World;
+import net.minecraft.entity.vehicle.VehicleInventory;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-@Mixin(value = {
-    StorageMinecartEntity.class,
-    ChestBoatEntity.class
-})
-public abstract class VehicleInventoryValidationMixin extends Entity {
-
-    public VehicleInventoryValidationMixin(EntityType<?> entityType, World world) {
-        super(entityType, world);
-    }
-
-    @Inject(method = "canPlayerUse", at = @At("RETURN"), cancellable = true)
-    private void canPlayerUseWithActualReachDistance(PlayerEntity playerEntity, CallbackInfoReturnable<Boolean> cir) {
-        double reachDistance = ReachEntityAttributes.getReachDistance(playerEntity, 8.0);
-        boolean canUse = !isRemoved() && this.getPos().isInRange(playerEntity.getPos(), reachDistance);
-        if(canUse != cir.getReturnValue()) {
-            cir.setReturnValue(canUse);
-        }
+@Mixin(VehicleInventory.class)
+interface VehicleInventoryValidationMixin {
+    @ModifyConstant(
+        method = "canPlayerAccess",
+        require = 1, allow = 1, constant = @Constant(doubleValue = 8.0))
+    private static double getActualReachDistance(final double reachDistance, final PlayerEntity player) {
+        return ReachEntityAttributes.getReachDistance(player, reachDistance);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,10 +23,10 @@
     "mixins.reach-entity-attributes.json"
   ],
   "depends": {
-    "minecraft": ">=1.19-rc.2",
-    "fabricloader": ">=0.11.3",
-    "fabric-registry-sync-v0": ">=0.9.8",
-    "fabric-resource-loader-v0": ">=0.4.7"
+    "minecraft": ">=1.19",
+    "fabricloader": ">=0.14.6",
+    "fabric-registry-sync-v0": ">=0.9.16",
+    "fabric-resource-loader-v0": ">=0.5.3"
   },
   "custom": {
     "modmenu": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "mixins.reach-entity-attributes.json"
   ],
   "depends": {
-    "minecraft": ">=1.17-beta.1",
+    "minecraft": ">=1.19-rc.2",
     "fabricloader": ">=0.11.3",
     "fabric-registry-sync-v0": ">=0.9.8",
     "fabric-resource-loader-v0": ">=0.4.7"

--- a/src/main/resources/mixins.reach-entity-attributes.json
+++ b/src/main/resources/mixins.reach-entity-attributes.json
@@ -18,7 +18,8 @@
     "PlayerEntityMixin",
     "ScreenHandlerMixin",
     "ServerPlayerInteractionManagerMixin",
-    "ServerPlayNetworkHandlerMixin"
+    "ServerPlayNetworkHandlerMixin",
+    "VehicleInventoryValidationMixin"
   ],
   "refmap": "refmap.reach-entity-attributes.json"
 }


### PR DESCRIPTION
A few things to note:

* The `@ModifyConstant` used in the `InventoryValidationMixin` no longer applies to `StorageMinecartEntity`, as the `canPlayerUse` method doesn't reference the reach distance directly anymore, but instead calls upon the default `canPlayerAccess` method of the `VehicleInventory` interface.
* One option was to overwrite the default method (since `@Inject` or `@Redirect` won't be able to target the method), but that seemed rather intrusive to me.
* The option I went with was creating a `VehicleInventoryValidationMixin`, which performs its own, separate check in the `canPlayerUse` method of the two implementing classes (`StorageMinecartEntity` and `ChestBoatEntity`).
* Several constants in `ServerPlayNetworkHandler` and `ServerPlayerInteractionManager` were changed to refer to a static field in `ServerPlayNetworkHandler` instead. I changed those mixins from `@ModifyConstant`s to `@Redirect`s of the field access.
* Mojang added an additional early return reach check in `ServerPlayNetworkHandler#onPlayerInteractBlock` which the mixin now also targets.
* I left the version at 2.2.0, since I wasn't sure how you prefer your versioning (some people keep the version if no features changed and just change the build metadata if Minecraft updates, others change the minor version).