### PR TITLE
Update to 1.20-pre6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel = true
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version = 1.19.4
-yarn_mappings = 1.19.4+build.2
-loader_version = 0.14.19
+minecraft_version = 1.20-pre6
+yarn_mappings = 1.20-pre6+build.2
+loader_version = 0.14.21
 
 # Mod Properties
-mod_version = 2.3.2
+mod_version = 2.3.3
 maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
-fabric_version = 0.78.0+1.19.4
+fabric_version = 0.82.1+1.20
 jsr305_version = 3.0.2

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/PlayerInventoryValidationMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/PlayerInventoryValidationMixin.java
@@ -1,0 +1,19 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(PlayerInventory.class)
+abstract class PlayerInventoryValidationMixin {
+    @ModifyConstant(
+        method = "canPlayerUse(Lnet/minecraft/entity/player/PlayerEntity;)Z",
+        require = 1, allow = 1, constant = @Constant(doubleValue = 64.0))
+    private static double getActualReachDistance(final double reachDistance, final PlayerEntity player) {
+        return ReachEntityAttributes.getSquaredReachDistance(player, reachDistance);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "mixins.reach-entity-attributes.json"
   ],
   "depends": {
-    "minecraft": "~1.19.4",
+    "minecraft": ">=1.19.4",
     "fabricloader": ">=0.14.19",
     "fabric-registry-sync-v0": ">=2.1.3",
     "fabric-resource-loader-v0": ">=0.11.1"

--- a/src/main/resources/mixins.reach-entity-attributes.json
+++ b/src/main/resources/mixins.reach-entity-attributes.json
@@ -1,6 +1,6 @@
 {
   "minVersion": "0.8",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "required": true,
   "package": "com.jamieswhiteshirt.reachentityattributes.mixin",
   "client": [
@@ -10,6 +10,7 @@
   "mixins": [
     "ChestStateManagerMixin",
     "ForgingScreenHandlerMixin",
+    "PlayerInventoryValidationMixin",
     "InventoryValidationMixin",
     "ItemMixin",
     "LivingEntityMixin",


### PR DESCRIPTION
There didn't seem to be a lot of changes required, just swapping out the "~1.19.4" for ">1.19.4" in the mod config. I did add the missing Mixin for PlayerInventory though, since I saw in the previous versions that point was targetted but left out in the current 1.19 branch.

Also since there isn't a 1.20 branch to target for the PR, I've had to leave it pointing at the 1.19 branch. Sorry about that.