### PR TITLE
Add Forge compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 import java.time.Instant
 
 plugins {
-    id "fabric-loom" version "1.3.2"
+    id "fabric-loom" version "1.5-SNAPSHOT"
     id "net.nemerosa.versioning" version "3.0.0"
     id "maven-publish"
     id "signing"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings = 1.20.4+build.3
 loader_version = 0.15.6
 
 # Mod Properties
-mod_version = 2.4.0
+mod_version = 2.4.1
 maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel = true
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version = 1.20
-yarn_mappings = 1.20+build.1
-loader_version = 0.14.21
+minecraft_version = 1.20.4
+yarn_mappings = 1.20.4+build.3
+loader_version = 0.15.6
 
 # Mod Properties
 mod_version = 2.4.0
@@ -14,5 +14,5 @@ maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 
 # Dependencies
-fabric_version = 0.83.0+1.20
+fabric_version = 0.95.3+1.20.4
 jsr305_version = 3.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings = 1.20.4+build.3
 loader_version = 0.15.6
 
 # Mod Properties
-mod_version = 2.4.1
+mod_version = 2.4.2
 maven_group = com.jamieswhiteshirt
 archives_base_name = reach-entity-attributes
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=5022b0b25fe182b0e50867e77f484501dba44feeea88f5c1f13b6b4660463640
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -83,10 +83,8 @@ done
 # This is normally unused
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,10 +131,13 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
@@ -144,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -152,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -197,11 +198,15 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        gradlePluginPortal()
         maven {
-            url = "https://maven.fabricmc.net"
+            name = 'Fabric'
+            url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
-
-rootProject.name = archives_base_name

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/MixinPlugin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/MixinPlugin.java
@@ -1,0 +1,47 @@
+package com.jamieswhiteshirt.reachentityattributes;
+
+import java.util.List;
+import java.util.Set;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+    private static final String FORGIFIED_MIXIN_PACKAGE = "com.jamieswhiteshirt.reachentityattributes.mixin.forgified";
+    @Override
+    public void onLoad(String mixinPackage) { }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+
+        switch (mixinClassName) {
+            case "com.jamieswhiteshirt.reachentityattributes.mixin.LivingEntityMixin":
+                return true;
+            default:
+        }
+
+        return mixinClassName.startsWith(FORGIFIED_MIXIN_PACKAGE) == FabricLoader.getInstance().isModLoaded("connectormod");
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) { }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) { }
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/BrushItemMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/BrushItemMixin.java
@@ -1,0 +1,20 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BrushItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BrushItem.class)
+abstract class BrushItemMixin {
+
+    @ModifyExpressionValue(
+        method = "getHitResult",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getReachDistance(Z)F"))
+    private float getActualReachDistance(float original, PlayerEntity playerEntity) {
+        return (float) ReachEntityAttributes.getReachDistance(playerEntity, original);
+    }
+
+}

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/VehicleInventoryValidationMixin.java
@@ -12,7 +12,7 @@ interface VehicleInventoryValidationMixin {
     @ModifyConstant(
         method = "canPlayerAccess(Lnet/minecraft/entity/player/PlayerEntity;)Z",
         require = 1, allow = 1, constant = @Constant(doubleValue = 8.0))
-    private static double getActualReachDistance(final double reachDistance, final PlayerEntity player) {
+    private double getActualReachDistance(final double reachDistance, final PlayerEntity player) {
         return ReachEntityAttributes.getReachDistance(player, reachDistance);
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/client/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/client/ClientPlayerInteractionManagerMixin.java
@@ -1,25 +1,25 @@
 package com.jamieswhiteshirt.reachentityattributes.mixin.client;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ClientPlayerInteractionManager.class)
 abstract class ClientPlayerInteractionManagerMixin {
     @Shadow @Final private MinecraftClient client;
 
-    @ModifyConstant(
-        method = "getReachDistance()F",
-        require = 2, allow = 2, constant = { @Constant(floatValue = 5.0F), @Constant(floatValue = 4.5F) })
-    private float getActualReachDistance(final float reachDistance) {
+    @ModifyExpressionValue(
+        method = "getReachDistance",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getReachDistance(Z)F"))
+    private float getActualReachDistance(float original) {
         if (this.client.player != null) {
-            return (float) ReachEntityAttributes.getReachDistance(this.client.player, reachDistance);
+            return (float) ReachEntityAttributes.getReachDistance(this.client.player, original);
         }
-        return reachDistance;
+        return original;
     }
 }

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/client/GameRendererMixin.java
@@ -1,14 +1,14 @@
 package com.jamieswhiteshirt.reachentityattributes.mixin.client;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.resource.SynchronousResourceReloader;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.*;
 
 @Mixin(GameRenderer.class)
 abstract class GameRendererMixin implements SynchronousResourceReloader/*, AutoCloseable*/ {
@@ -24,12 +24,14 @@ abstract class GameRendererMixin implements SynchronousResourceReloader/*, AutoC
         return reachDistance;
     }
 
-    @ModifyConstant(method = "updateTargetedEntity(F)V", constant = @Constant(doubleValue = 3.0))
-    private double getActualAttackRange0(final double attackRange) {
+    @ModifyVariable(
+        method = "updateTargetedEntity",
+        at = @At(value = "STORE"), ordinal = 1)
+    private boolean getActualAttackRange0(boolean hasExtendedReach, @Local(ordinal = 0) double reachDistance) {
         if (this.client.player != null) {
-            return ReachEntityAttributes.getAttackRange(this.client.player, attackRange);
+            return reachDistance > ReachEntityAttributes.getAttackRange(this.client.player, 3.0);
         }
-        return attackRange;
+        return hasExtendedReach;
     }
 
     @ModifyConstant(method = "updateTargetedEntity(F)V", constant = @Constant(doubleValue = 9.0))

--- a/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/forgified/IForgePlayerMixin.java
+++ b/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/forgified/IForgePlayerMixin.java
@@ -1,0 +1,26 @@
+package com.jamieswhiteshirt.reachentityattributes.mixin.forgified;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+
+import net.minecraft.entity.player.PlayerEntity;
+
+@Pseudo
+@Mixin(targets = "net.minecraftforge.common.extensions.IForgePlayer")
+public interface IForgePlayerMixin {
+
+    @Inject(method = "getBlockReach()D", at = @At("RETURN"), cancellable = true)
+    private void getActualBlockReach(CallbackInfoReturnable<Double> info) {
+        info.setReturnValue(ReachEntityAttributes.getReachDistance((PlayerEntity)this, info.getReturnValue()));
+    }
+
+    @Inject(method = "getEntityReach()D", at = @At("RETURN"), cancellable = true)
+    private void getActualEntityReach(CallbackInfoReturnable<Double> info) {
+        info.setReturnValue(ReachEntityAttributes.getAttackRange((PlayerEntity)this, info.getReturnValue()));
+    }
+}

--- a/src/main/resources/mixins.reach-entity-attributes.json
+++ b/src/main/resources/mixins.reach-entity-attributes.json
@@ -2,6 +2,7 @@
     "minVersion": "0.8",
     "compatibilityLevel": "JAVA_16",
     "required": true,
+    "plugin" : "com.jamieswhiteshirt.reachentityattributes.MixinPlugin",
     "package": "com.jamieswhiteshirt.reachentityattributes.mixin",
     "client": [
         "client.ClientPlayerInteractionManagerMixin",
@@ -19,7 +20,8 @@
         "ScreenHandlerMixin",
         "ServerPlayerInteractionManagerMixin",
         "ServerPlayNetworkHandlerMixin",
-        "VehicleInventoryValidationMixin"
+        "VehicleInventoryValidationMixin",
+        "forgified.IForgePlayerMixin"
     ],
     "refmap": "refmap.reach-entity-attributes.json"
 }

--- a/src/main/resources/mixins.reach-entity-attributes.json
+++ b/src/main/resources/mixins.reach-entity-attributes.json
@@ -1,24 +1,25 @@
 {
-  "minVersion": "0.8",
-  "compatibilityLevel": "JAVA_16",
-  "required": true,
-  "package": "com.jamieswhiteshirt.reachentityattributes.mixin",
-  "client": [
-    "client.ClientPlayerInteractionManagerMixin",
-    "client.GameRendererMixin"
-  ],
-  "mixins": [
-    "ChestStateManagerMixin",
-    "ForgingScreenHandlerMixin",
-    "InventoryValidationMixin",
-    "ItemMixin",
-    "LivingEntityMixin",
-    "PlayerEntityInteractionHandlerMixin",
-    "PlayerEntityMixin",
-    "ScreenHandlerMixin",
-    "ServerPlayerInteractionManagerMixin",
-    "ServerPlayNetworkHandlerMixin",
-    "VehicleInventoryValidationMixin"
-  ],
-  "refmap": "refmap.reach-entity-attributes.json"
+    "minVersion": "0.8",
+    "compatibilityLevel": "JAVA_16",
+    "required": true,
+    "package": "com.jamieswhiteshirt.reachentityattributes.mixin",
+    "client": [
+        "client.ClientPlayerInteractionManagerMixin",
+        "client.GameRendererMixin"
+    ],
+    "mixins": [
+        "BrushItemMixin",
+        "ChestStateManagerMixin",
+        "ForgingScreenHandlerMixin",
+        "InventoryValidationMixin",
+        "ItemMixin",
+        "LivingEntityMixin",
+        "PlayerEntityInteractionHandlerMixin",
+        "PlayerEntityMixin",
+        "ScreenHandlerMixin",
+        "ServerPlayerInteractionManagerMixin",
+        "ServerPlayNetworkHandlerMixin",
+        "VehicleInventoryValidationMixin"
+    ],
+    "refmap": "refmap.reach-entity-attributes.json"
 }


### PR DESCRIPTION
This makes is so the game will no longer crash when loading with Forge/Neo via Synatra Connector.

I just exclude all the mixins except essential ones add a new mixin into IForgePlayer#getBlockReach and IForgePlayer#getEntityReach so this mod's version of the attributes are still applied.

Also included is #35 to port to 1.20.4 as I needed that in my build.